### PR TITLE
Fixed out of range error for BC timestamp test

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -77,7 +77,7 @@ class TimestampTest < ActiveRecord::TestCase
   end
 
   def test_bc_timestamp
-    date = Date.new(0) - 1.second
+    date = Date.new(0) - 1.day
     Developer.create!(:name => "aaron", :updated_at => date)
     assert_equal date, Developer.find_by_name("aaron").updated_at
   end


### PR DESCRIPTION
Old test issue reappeared, see link for details: https://github.com/rails/rails/pull/12234

ActiveRecord test suite fails for BC Timestamp for Postgres because of timezone differences; fixed by changing to an entire day instead of one second in BC.
