### PR TITLE
context on validates goes through has many relationship

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -301,7 +301,7 @@ module ActiveRecord
       def association_valid?(reflection, record)
         return true if record.destroyed? || record.marked_for_destruction?
 
-        unless valid = record.valid?
+        unless valid = record.valid?(self.validation_context)
           if reflection.options[:autosave]
             record.errors.each do |attribute, message|
               attribute = "#{reflection.name}.#{attribute}"

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -22,6 +22,8 @@ require 'models/engine'
 require 'models/categorization'
 require 'models/minivan'
 require 'models/speedometer'
+require 'models/pirate'
+require 'models/ship'
 
 class HasManyAssociationsTestForReorderWithJoinDependency < ActiveRecord::TestCase
   fixtures :authors, :posts, :comments
@@ -1829,5 +1831,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
         end
       end
     end
+  end
+
+  test 'has_many_association passes context validation to validate children' do
+    pirate = FamousPirate.new
+    pirate.famous_ships << ship = FamousShip.new
+    assert_equal true, pirate.valid?
+    assert_equal false, pirate.valid?(:conference)
+    assert_equal "can't be blank", ship.errors[:name].first
   end
 end

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -85,3 +85,11 @@ end
 class DestructivePirate < Pirate
   has_one :dependent_ship, :class_name => 'Ship', :foreign_key => :pirate_id, :dependent => :destroy
 end
+
+class FamousPirate < ActiveRecord::Base
+  self.table_name = 'pirates'
+
+  has_many :famous_ships
+
+  validates_presence_of :catchphrase, on: :conference
+end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -17,3 +17,11 @@ class Ship < ActiveRecord::Base
     false
   end
 end
+
+class FamousShip < ActiveRecord::Base
+  self.table_name = 'ships'
+
+  belongs_to :famous_pirate
+
+  validates_presence_of :name, on: :conference
+end


### PR DESCRIPTION
This should resolve #13854.  An object that has many objects when validated against a context will also validate its children against the context.  Modified Ship and Pirate to utilize a custom context with has_many
